### PR TITLE
Add fallback for encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const { parse } = require('qs')
 
 module.exports = async function parseFormData (req, {limit = '1mb'} = {}) {
   const type = req.headers['content-type']
-  const encoding = typer.parse(type).parameters.charset
+  const encoding = (type) ? typer.parse(type).parameters.charset : 'UTF-8'
 
   req.rawBody = req.rawBody || getRawBody(req, {limit, encoding})
   const str = await req.rawBody


### PR DESCRIPTION
- encoding fallbacks to `UTF-8`
- getting TypeError in media typer when content type is missing
- related to https://github.com/zeit/micro/pull/208